### PR TITLE
Create SyncDateTime.py

### DIFF
--- a/SyncDateTime.py
+++ b/SyncDateTime.py
@@ -1,0 +1,12 @@
+import requests
+import subprocess
+
+x = requests.get('https://www.timeapi.io/api/time/current/zone?timeZone=Australia%2FBrisbane')
+
+data = x.json()
+
+formatted = f"{data['year']}-{data['month']}-{data['day']} {data['hour']}:{data['minute']}:{data['seconds']}"
+
+cmd = f'date -s "{formatted}"'
+print(cmd)
+subprocess.run(['sudo', 'bash', '-c', cmd])


### PR DESCRIPTION
Script for syncing devices datetime. As there is no NTP service in dietpi, using a simple API call we sync the devices datetime to allow updating/transfers/etc.  This script allows us to alter the api service/timezone params if needed.